### PR TITLE
Add gh-extension release via GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+---
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      time: '11:00'
+    groups:
+      all:
+        patterns:
+          - "*"  # Group all updates into a single larger pull request.
+
+  # Maintain Go module dependencies
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      time: '11:00'
+    groups:
+      all:
+        patterns:
+          - "*"  # Group all updates into a single larger pull request.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: release
+on:
+  push:
+    tags:
+      - "v*"
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  release:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: cli/gh-extension-precompile@v2
+        with:
+          generate_attestations: true
+          go_version_file: go.mod

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/gh-reaction.out
+/gh-reaction
+/gh-reaction.exe


### PR DESCRIPTION
The binary is now built and released via the GitHub Actions workflow.

This will prevent user to build the binary manually.

This also removes the need for users to have Go installed on their
machines.
