### PR TITLE
Track and display GraphQL API cost and rate limit

### DIFF
--- a/internal/app/render.go
+++ b/internal/app/render.go
@@ -18,20 +18,17 @@ type postWithReactions struct {
 	MostRecentReaction time.Time
 }
 
-func renderReactions(since timeago.RelativeDate, reactions []gh.ReactionResult, emptyLabel string) {
-	fmt.Println()
+func renderReactions(since timeago.RelativeDate, result gh.QueryResult, emptyLabel string) {
 
-	if len(reactions) == 0 {
+	if len(result.Reactions) == 0 {
 		fmt.Println("Stats since", since)
-		fmt.Println(len(reactions), emptyLabel)
-		fmt.Println()
+		fmt.Println(len(result.Reactions), emptyLabel)
 		return
 	}
 
-	allReactions := buildReactions(reactions)
+	allReactions := buildReactions(result.Reactions)
 	allReactions.Clean()
 
-	fmt.Println()
 	fmt.Println("Posts with reactions (sorted by most recent reaction, oldest -> newest):")
 
 	postGroups := groupReactionsByPost(allReactions)

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -26,6 +26,15 @@ func parseSinceFlag(sinceFlag string) (timeago.RelativeDate, error) {
 	return since, nil
 }
 
+func displayAPIStats(ctx context.Context, result gh.QueryResult) {
+	fmt.Printf("\nGraphQL cost: %d", result.Cost)
+	rateLimit, err := gh.FetchRateLimit(ctx)
+	if err == nil {
+		fmt.Printf(" | Remaining: %d/%d", rateLimit.Remaining, rateLimit.Limit)
+	}
+	fmt.Println()
+}
+
 func RunUser(ctx context.Context, sinceFlag string, args []string) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -55,12 +64,14 @@ func RunUser(ctx context.Context, sinceFlag string, args []string) error {
 		author = me.Login
 	}
 
-	reactions, err := gh.QueryUser(ctx, since, author)
+	result, err := gh.QueryUser(ctx, since, author)
 	if err != nil {
 		return err
 	}
 
-	renderReactions(since, reactions, "messages with reactions")
+	displayAPIStats(ctx, result)
+	fmt.Println()
+	renderReactions(since, result, "messages with reactions")
 	return nil
 }
 
@@ -88,11 +99,13 @@ func RunRepository(ctx context.Context, sinceFlag string, args []string) error {
 		}
 	}
 
-	reactions, err := gh.QueryRepository(ctx, since, *repo)
+	result, err := gh.QueryRepository(ctx, since, *repo)
 	if err != nil {
 		return err
 	}
 
-	renderReactions(since, reactions, "reactions on repository items")
+	displayAPIStats(ctx, result)
+	fmt.Println()
+	renderReactions(since, result, "reactions on repository items")
 	return nil
 }

--- a/internal/gh/queries/author_commit_comments.graphql
+++ b/internal/gh/queries/author_commit_comments.graphql
@@ -1,4 +1,7 @@
 query ($login: String!, $last_reaction: Int!, $nb: Int!, $cursor: String) {
+  rateLimit {
+    cost
+  }
   user(login: $login) {
     commitComments(last: $nb, before: $cursor) {
       totalCount

--- a/internal/gh/queries/author_issue_comments.graphql
+++ b/internal/gh/queries/author_issue_comments.graphql
@@ -1,4 +1,7 @@
 query ($login: String!, $last_reaction: Int!, $nb: Int!, $cursor: String) {
+  rateLimit {
+    cost
+  }
   user(login: $login) {
     issueComments(last: $nb, before: $cursor) {
       totalCount

--- a/internal/gh/queries/author_issues.graphql
+++ b/internal/gh/queries/author_issues.graphql
@@ -1,4 +1,7 @@
 query ($login: String!, $last_reaction: Int!, $nb: Int!, $cursor: String) {
+  rateLimit {
+    cost
+  }
   user(login: $login) {
     issues(last: $nb, before: $cursor) {
       totalCount

--- a/internal/gh/queries/author_pull_requests.graphql
+++ b/internal/gh/queries/author_pull_requests.graphql
@@ -1,4 +1,7 @@
 query ($login: String!, $last_reaction: Int!, $nb: Int!, $cursor: String) {
+  rateLimit {
+    cost
+  }
   user(login: $login) {
     pullRequests(last: $nb, before: $cursor) {
       totalCount

--- a/internal/gh/queries/author_reactions_by_node.graphql
+++ b/internal/gh/queries/author_reactions_by_node.graphql
@@ -1,4 +1,7 @@
 query ($id: ID!, $last_reaction: Int!, $cursor: String) {
+  rateLimit {
+    cost
+  }
   node(id: $id) {
     ... on Reactable {
       reactions(last: $last_reaction, before: $cursor) {

--- a/internal/gh/queries/author_repository_discussion_comments.graphql
+++ b/internal/gh/queries/author_repository_discussion_comments.graphql
@@ -1,4 +1,7 @@
 query ($login: String!, $last_reaction: Int!, $nb: Int!, $cursor: String) {
+  rateLimit {
+    cost
+  }
   user(login: $login) {
     repositoryDiscussionComments(last: $nb, before: $cursor) {
       totalCount

--- a/internal/gh/queries/author_repository_discussions.graphql
+++ b/internal/gh/queries/author_repository_discussions.graphql
@@ -1,4 +1,7 @@
 query ($login: String!, $last_reaction: Int!, $nb: Int!, $cursor: String) {
+  rateLimit {
+    cost
+  }
   user(login: $login) {
     repositoryDiscussions(last: $nb, before: $cursor) {
       totalCount

--- a/internal/gh/queries/rate_limit.go
+++ b/internal/gh/queries/rate_limit.go
@@ -1,0 +1,8 @@
+package queries
+
+import _ "embed"
+
+var (
+	//go:embed rate_limit.graphql
+	RateLimit string
+)

--- a/internal/gh/queries/rate_limit.graphql
+++ b/internal/gh/queries/rate_limit.graphql
@@ -1,0 +1,7 @@
+query {
+  rateLimit {
+    cost
+    remaining
+    limit
+  }
+}

--- a/internal/gh/queries/repository_discussion_comments.graphql
+++ b/internal/gh/queries/repository_discussion_comments.graphql
@@ -1,4 +1,7 @@
 query ($owner: String!, $name: String!, $last_reaction: Int!, $nb: Int!, $cursor: String) {
+  rateLimit {
+    cost
+  }
   repository(owner: $owner, name: $name) {
     discussions(first: $nb, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {
       totalCount

--- a/internal/gh/queries/repository_discussions.graphql
+++ b/internal/gh/queries/repository_discussions.graphql
@@ -1,4 +1,7 @@
 query ($owner: String!, $name: String!, $last_reaction: Int!, $nb: Int!, $cursor: String) {
+  rateLimit {
+    cost
+  }
   repository(owner: $owner, name: $name) {
     discussions(first: $nb, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {
       totalCount

--- a/internal/gh/queries/repository_issue_comments.graphql
+++ b/internal/gh/queries/repository_issue_comments.graphql
@@ -1,4 +1,7 @@
 query ($owner: String!, $name: String!, $last_reaction: Int!, $nb: Int!, $cursor: String) {
+  rateLimit {
+    cost
+  }
   repository(owner: $owner, name: $name) {
     issues(first: $nb, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {
       totalCount

--- a/internal/gh/queries/repository_issues.graphql
+++ b/internal/gh/queries/repository_issues.graphql
@@ -1,4 +1,7 @@
 query ($owner: String!, $name: String!, $last_reaction: Int!, $nb: Int!, $cursor: String) {
+  rateLimit {
+    cost
+  }
   repository(owner: $owner, name: $name) {
     issues(first: $nb, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {
       totalCount

--- a/internal/gh/queries/repository_pull_requests.graphql
+++ b/internal/gh/queries/repository_pull_requests.graphql
@@ -1,4 +1,7 @@
 query ($owner: String!, $name: String!, $last_reaction: Int!, $nb: Int!, $cursor: String) {
+  rateLimit {
+    cost
+  }
   repository(owner: $owner, name: $name) {
     pullRequests(first: $nb, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {
       totalCount

--- a/internal/gh/query.go
+++ b/internal/gh/query.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ccoVeille/gh-reaction/internal/gh/queries"
@@ -25,6 +26,12 @@ type PageInfo struct {
 
 func (p PageInfo) IsZero() bool {
 	return !p.HasNextPage && !p.HasPreviousPage
+}
+
+type RateLimit struct {
+	Cost      int `json:"cost"`
+	Remaining int `json:"remaining"`
+	Limit     int `json:"limit"`
 }
 
 type Reaction struct {
@@ -95,6 +102,12 @@ type resReaction struct {
 // ReactionResult exposes reaction data for consumers without exporting internals.
 type ReactionResult = resReaction
 
+// QueryResult contains the reactions and the GraphQL cost of the query.
+type QueryResult struct {
+	Reactions []ReactionResult
+	Cost      int64
+}
+
 type resNode struct {
 	TotalCount int      `json:"totalCount,omitempty"`
 	PageInfo   PageInfo `json:"pageInfo,omitzero"`
@@ -112,7 +125,8 @@ func (b Body) MarshalJSON() ([]byte, error) {
 }
 
 type resAPISingle struct {
-	User struct {
+	RateLimit RateLimit `json:"rateLimit"`
+	User      struct {
 		CommitComments               resNode `json:"commitComments,omitzero"`
 		IssueComments                resNode `json:"issueComments,omitzero"`
 		Issues                       resNode `json:"issues,omitzero"`
@@ -161,12 +175,14 @@ func (r *resAPISingle) extractByObjectType(requestType string, objType ObjectTyp
 }
 
 type resAPINodeReactions struct {
-	Node struct {
+	RateLimit RateLimit `json:"rateLimit"`
+	Node      struct {
 		Reactions Reactions `json:"reactions"`
 	} `json:"node"`
 }
 
 type resAPIRepoIssueComments struct {
+	RateLimit  RateLimit `json:"rateLimit"`
 	Repository struct {
 		Issues struct {
 			TotalCount int      `json:"totalCount,omitempty"`
@@ -179,6 +195,7 @@ type resAPIRepoIssueComments struct {
 }
 
 type resAPIRepoDiscussionComments struct {
+	RateLimit  RateLimit `json:"rateLimit"`
 	Repository struct {
 		Discussions struct {
 			TotalCount int      `json:"totalCount,omitempty"`
@@ -195,13 +212,14 @@ type requester struct {
 	author  string
 	minDate timeago.RelativeDate
 	spin    *spinner.Spinner
+	cost    atomic.Int64
 }
 
 // QueryUser fetches messages posted by the user using separate queries per post type
-func QueryUser(ctx context.Context, minDate timeago.RelativeDate, author string) ([]ReactionResult, error) {
+func QueryUser(ctx context.Context, minDate timeago.RelativeDate, author string) (QueryResult, error) {
 	clientGraphQL, err := api.DefaultGraphQLClient()
 	if err != nil {
-		return nil, err
+		return QueryResult{}, err
 	}
 
 	suffix := fmt.Sprintf("on github.com since %s", minDate.String())
@@ -265,7 +283,7 @@ func QueryUser(ctx context.Context, minDate timeago.RelativeDate, author string)
 		}
 	}
 	if len(errs) > 0 {
-		return nil, fmt.Errorf("errors fetching reactions: %v", errs)
+		return QueryResult{}, fmt.Errorf("errors fetching reactions: %v", errs)
 	}
 
 	// Collect results
@@ -288,7 +306,10 @@ func QueryUser(ctx context.Context, minDate timeago.RelativeDate, author string)
 		return 0
 	})
 
-	return allReactions, nil
+	return QueryResult{
+		Reactions: allReactions,
+		Cost:      req.cost.Load(),
+	}, nil
 }
 
 func (r *requester) fetchUserPostsReactions(
@@ -311,6 +332,8 @@ func (r *requester) fetchUserPostsReactions(
 		if err != nil {
 			return nil, err
 		}
+
+		r.cost.Add(int64(res.RateLimit.Cost))
 
 		nodes := res.extractByObjectType("user", objectType)
 		var hasRecentPosts bool
@@ -398,6 +421,8 @@ func (r *requester) fetchAllReactionsForNode(
 			return nil, err
 		}
 
+		r.cost.Add(int64(res.RateLimit.Cost))
+
 		reactions := res.Node.Reactions
 		if len(reactions.Nodes) == 0 {
 			break
@@ -415,10 +440,10 @@ func (r *requester) fetchAllReactionsForNode(
 }
 
 // QueryRepository fetches reactions on posts in a specific repository
-func QueryRepository(ctx context.Context, minDate timeago.RelativeDate, repo Repository) ([]ReactionResult, error) {
+func QueryRepository(ctx context.Context, minDate timeago.RelativeDate, repo Repository) (QueryResult, error) {
 	clientGraphQL, err := api.DefaultGraphQLClient()
 	if err != nil {
-		return nil, err
+		return QueryResult{}, err
 	}
 
 	suffix := fmt.Sprintf("in %s/%s since %s", repo.Owner, repo.Name, minDate.String())
@@ -492,7 +517,7 @@ func QueryRepository(ctx context.Context, minDate timeago.RelativeDate, repo Rep
 		}
 	}
 	if len(errs) > 0 {
-		return nil, fmt.Errorf("errors fetching reactions: %v", errs)
+		return QueryResult{}, fmt.Errorf("errors fetching reactions: %v", errs)
 	}
 
 	// Collect results
@@ -515,7 +540,10 @@ func QueryRepository(ctx context.Context, minDate timeago.RelativeDate, repo Rep
 		return 0
 	})
 
-	return allReactions, nil
+	return QueryResult{
+		Reactions: allReactions,
+		Cost:      req.cost.Load(),
+	}, nil
 }
 
 func (r *requester) fetchRepositoryItemsReactions(
@@ -540,6 +568,8 @@ func (r *requester) fetchRepositoryItemsReactions(
 		if err != nil {
 			return nil, err
 		}
+
+		r.cost.Add(int64(res.RateLimit.Cost))
 
 		nodes := res.extractByObjectType("repository", objectType)
 		var hasRecentPosts bool
@@ -631,6 +661,8 @@ func (r *requester) fetchRepositoryIssueCommentsReactions(
 			return nil, err
 		}
 
+		r.cost.Add(int64(res.RateLimit.Cost))
+
 		issues := res.Repository.Issues
 		var hasRecentPosts bool
 
@@ -717,6 +749,8 @@ func (r *requester) fetchRepositoryDiscussionCommentsReactions(
 			return nil, err
 		}
 
+		r.cost.Add(int64(res.RateLimit.Cost))
+
 		discussions := res.Repository.Discussions
 		var hasRecentPosts bool
 
@@ -775,4 +809,22 @@ func (r *requester) fetchRepositoryDiscussionCommentsReactions(
 	}
 
 	return reactions, nil
+}
+
+// FetchRateLimit fetches the current GraphQL API rate limit status
+func FetchRateLimit(ctx context.Context) (RateLimit, error) {
+	client, err := api.DefaultGraphQLClient()
+	if err != nil {
+		return RateLimit{}, err
+	}
+
+	var res struct {
+		RateLimit RateLimit `json:"rateLimit"`
+	}
+
+	if err := client.DoWithContext(ctx, queries.RateLimit, nil, &res); err != nil {
+		return RateLimit{}, err
+	}
+
+	return res.RateLimit, nil
 }


### PR DESCRIPTION
- Add rateLimit { cost } field to all GraphQL queries
- Introduce QueryResult struct wrapping reactions and total cost
- Accumulate per-query costs atomically via requester.cost
- Add FetchRateLimit helper and dedicated rate_limit.graphql query
- Display GraphQL cost and remaining rate limit after each run

Closes #30 