### PR TITLE
feat: support release reactions for repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This tool fills that gap by querying GitHub's GraphQL API to fetch all reactions
 
 ```console
 $ gh reaction
-A CLI tool to analyze GitHub reactions (emojis) on your or someone else's posts (issues, PRs, comments).
+A CLI tool to analyze GitHub reactions (emojis) on your or someone else's posts (issues, PRs, releases, comments).
 
 Usage:
   gh-reaction [command]

--- a/internal/app/render.go
+++ b/internal/app/render.go
@@ -72,6 +72,9 @@ func buildReactions(reactions []gh.ReactionResult) Reactions {
 	var allReactions Reactions
 	for _, reaction := range reactions {
 		content := string(reaction.Parent.Title)
+		if reaction.Type == gh.ObjectTypeRelease && reaction.Parent.Name != "" {
+			content += " " + reaction.Parent.Name
+		}
 		if content == "" {
 			content = string(reaction.Parent.Body)
 		}
@@ -99,7 +102,7 @@ func buildReactions(reactions []gh.ReactionResult) Reactions {
 					Type:     reaction.Parent.Author.Type,
 					IsViewer: reaction.Parent.Author.IsViewer,
 				},
-				Content: content,
+				Content: strings.TrimSpace(content),
 				Link:    reaction.Parent.URL,
 			},
 		})

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -18,6 +18,7 @@ type PostType string
 const (
 	PostTypeIssue        PostType = "issue"
 	PostTypePullRequest  PostType = "pull_request"
+	PostTypeRelease      PostType = "release"
 	PostTypeComment      PostType = "comment"
 	PostTypeIssueComment PostType = "issue_comment"
 	PostTypePRComment    PostType = "pull_request_comment"
@@ -33,6 +34,8 @@ func (pt PostType) String() string {
 		return "pull request"
 	case PostTypeIssue:
 		return "issue"
+	case PostTypeRelease:
+		return "release"
 	case PostTypeComment:
 		return "comment"
 	default:

--- a/internal/gh/queries/repository.go
+++ b/internal/gh/queries/repository.go
@@ -3,6 +3,9 @@ package queries
 import _ "embed"
 
 var (
+	//go:embed repository_releases.graphql
+	RepositoryReleases string
+
 	//go:embed repository_pull_requests.graphql
 	RepositoryPullRequests string
 

--- a/internal/gh/queries/repository_releases.graphql
+++ b/internal/gh/queries/repository_releases.graphql
@@ -1,0 +1,49 @@
+query ($owner: String!, $name: String!, $last_reaction: Int!, $nb: Int!, $cursor: String) {
+  rateLimit {
+    cost
+  }
+  repository(owner: $owner, name: $name) {
+    releases(first: $nb, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        name
+        body: description
+        author {
+          __typename
+          login
+          ... on User {
+            name
+            isViewer
+          }
+        }
+        createdAt
+        updatedAt
+        url
+        reactions(last: $last_reaction) {
+          totalCount
+          pageInfo {
+            hasPreviousPage
+            startCursor
+          }
+          nodes {
+            content
+            createdAt
+            user {
+              __typename
+              login
+              ... on User {
+                name
+                isViewer
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/gh/query.go
+++ b/internal/gh/query.go
@@ -59,6 +59,7 @@ type Node struct {
 type NodeMetadata struct {
 	ID     string `json:"id"`
 	Title  string `json:"title,omitempty"`
+	Name   string `json:"name,omitempty"`
 	Body   Body   `json:"body,omitempty"`
 	Author struct {
 		Login    string `json:"login"`
@@ -85,6 +86,7 @@ type ObjectType string
 
 const (
 	ObjectTypePullRequest        ObjectType = "pull_request"
+	ObjectTypeRelease            ObjectType = "release"
 	ObjectTypePullRequestComment ObjectType = "pull_request_comment"
 	ObjectTypeIssue              ObjectType = "issue"
 	ObjectTypeIssueComment       ObjectType = "issue_comment"
@@ -137,6 +139,7 @@ type resAPISingle struct {
 	Repository struct {
 		Issues        resNode `json:"issues,omitzero"`
 		IssueComments resNode `json:"issueComments,omitzero"`
+		Releases      resNode `json:"releases,omitzero"`
 		PullRequests  resNode `json:"pullRequests,omitzero"`
 		Discussions   resNode `json:"discussions,omitzero"`
 	} `json:"repository"`
@@ -147,6 +150,8 @@ func (r *resAPISingle) extractByObjectType(requestType string, objType ObjectTyp
 		switch objType {
 		case ObjectTypePullRequest:
 			return r.Repository.PullRequests
+		case ObjectTypeRelease:
+			return r.Repository.Releases
 		case ObjectTypeIssue:
 			return r.Repository.Issues
 		case ObjectTypeIssueComment:
@@ -461,6 +466,7 @@ func QueryRepository(ctx context.Context, minDate timeago.RelativeDate, repo Rep
 	// Define post type configurations for repository
 	postTypes := map[ObjectType]string{
 		ObjectTypePullRequest:       queries.RepositoryPullRequests,
+		ObjectTypeRelease:           queries.RepositoryReleases,
 		ObjectTypeIssue:             queries.RepositoryIssues,
 		ObjectTypeDiscussion:        queries.RepositoryDiscussions,
 		ObjectTypeDiscussionComment: queries.RepositoryDiscussionComments,


### PR DESCRIPTION
Allow fetching and displaying reactions on repository releases, in addition to issues and pull requests.

This makes release feedback visible in the same workflow so reactions on release announcements are not missed.

No solution was found to do that in the user mode even if the user is the one who created the release, so this is only supported in the repository mode.

Fixes #29