### PR TITLE
chore: normalize Go module path casing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ccoVeille/gh-reaction
+module github.com/ccoveille/gh-reaction
 
 go 1.25.0
 

--- a/internal/app/render.go
+++ b/internal/app/render.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ccoVeille/gh-reaction/internal/gh"
-	"github.com/ccoVeille/gh-reaction/internal/github"
-	"github.com/ccoVeille/gh-reaction/internal/timeago"
+	"github.com/ccoveille/gh-reaction/internal/gh"
+	"github.com/ccoveille/gh-reaction/internal/github"
+	"github.com/ccoveille/gh-reaction/internal/timeago"
 )
 
 type postWithReactions struct {

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ccoVeille/gh-reaction/internal/gh"
-	"github.com/ccoVeille/gh-reaction/internal/timeago"
+	"github.com/ccoveille/gh-reaction/internal/gh"
+	"github.com/ccoveille/gh-reaction/internal/timeago"
 )
 
 const DefaultSinceDaysAgo = 90

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ccoVeille/gh-reaction/internal/github"
-	"github.com/ccoVeille/gh-reaction/internal/timeago"
+	"github.com/ccoveille/gh-reaction/internal/github"
+	"github.com/ccoveille/gh-reaction/internal/timeago"
 )
 
 type PostType string

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/ccoVeille/gh-reaction/internal/app"
+	"github.com/ccoveille/gh-reaction/internal/app"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/repository.go
+++ b/internal/cmd/repository.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/ccoVeille/gh-reaction/internal/app"
+	"github.com/ccoveille/gh-reaction/internal/app"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/user.go
+++ b/internal/cmd/user.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/ccoVeille/gh-reaction/internal/app"
+	"github.com/ccoveille/gh-reaction/internal/app"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/gh/query.go
+++ b/internal/gh/query.go
@@ -11,9 +11,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ccoVeille/gh-reaction/internal/gh/queries"
-	"github.com/ccoVeille/gh-reaction/internal/spinner"
-	"github.com/ccoVeille/gh-reaction/internal/timeago"
+	"github.com/ccoveille/gh-reaction/internal/gh/queries"
+	"github.com/ccoveille/gh-reaction/internal/spinner"
+	"github.com/ccoveille/gh-reaction/internal/timeago"
 	"github.com/cli/go-gh/v2/pkg/api"
 )
 

--- a/internal/github/resource.go
+++ b/internal/github/resource.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ccoVeille/gh-reaction/internal/timeago"
+	"github.com/ccoveille/gh-reaction/internal/timeago"
 )
 
 // User wraps github.User to provide additional methods.

--- a/internal/timeago/duration_test.go
+++ b/internal/timeago/duration_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ccoVeille/gh-reaction/internal/timeago"
+	"github.com/ccoveille/gh-reaction/internal/timeago"
 )
 
 func TestConvert(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/ccoVeille/gh-reaction/internal/cmd"
+	"github.com/ccoveille/gh-reaction/internal/cmd"
 )
 
 func run() error {


### PR DESCRIPTION
All my other repositories use lowercase module paths, this one was wrongly created with an uppercase letter in the path.

This commit renames the module path to be fully lowercase.

By convention, Go module paths should be in lowercase to avoid issues with case sensitivity across different filesystems.

CC @dolmen who reported this to me.

Some context: https://github.com/sirupsen/logrus/pull/859